### PR TITLE
Permite que o datepicker seja instanciado em um element com ng-attr-id

### DIFF
--- a/src/scripts/datepicker.js
+++ b/src/scripts/datepicker.js
@@ -1,7 +1,7 @@
 !function( $, ng ) {
 	"use strict";
 
-	ng.module( "syonet" ).directive( "syoDatepicker", function() {
+	ng.module( "syonet" ).directive( "syoDatepicker", [ "$timeout", function( $timeout ) {
 		var definition = {};
 
 		definition.restrict = "A";
@@ -31,7 +31,9 @@
 			}
 
 			// Instancia o datepicker
-			$element.datepicker( options );
+			$timeout(function() {
+				$element.datepicker( options );
+			});
 
 			// Quando há um botão para exibir o datepicker...
 			$button = $element.next( ".ui-datepicker-trigger" );
@@ -47,6 +49,6 @@
 		};
 
 		return definition;
-	});
+	}]);
 
 }( jQuery, angular );


### PR DESCRIPTION
O datepicker do jQueryUI necessita do `id` do input para modificar o seu valor quando a data for mudada. No meu caso o `id` é definido dinamicamente usando angular (`ng-attr-id="campo-{{ campo.id }}"`).

Quando Angular executa o post-link, é seguro manipular o DOM, setar eventos, etc. mas o view só será atualizado no próximo digest cycle, por essa razão o datepicker é instanciado em um elemento sem `id` (a única coisa visível é o `ng-attr-id...` que o jQuery UI não reconhece).

Quando o jQueryUI não identifica um id no elemento em que ele está sendo instanciado, ele cria um id no formato "dp000", sendo "000" um valor aleatório para cada instância do datepicker. Mas quando o Angular atualizar o view com o novo `id`, o antigo some e o jQueryUI nunca mais encontra o input com o `id` que ele criou, portanto é lançado "Missing instance data for this datepicker" cada vez que for executada alguma ação no datepicker.

Esta PR utiliza `$timeout` para que a instância do jQuery UI seja criada em um novo digest cycle após o view ter sido atualizado, com isso o `id` do elemento estará visível e o jqueryUI conseguirá encontrar o input.

Não existe workaround para fazer o `ng-attr-id` funcionar junto com o `syoDatepicker` sem modificar no bootstrap.